### PR TITLE
Cleanup packages so all objects are imported as org.konigsoftware.kontext.*

### DIFF
--- a/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextClientInterceptor.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextClientInterceptor.kt
@@ -1,4 +1,4 @@
-package org.konigsoftware.konig.kontext
+package org.konigsoftware.kontext
 
 import io.grpc.CallOptions
 import io.grpc.Channel
@@ -9,8 +9,6 @@ import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener
 import io.grpc.Metadata
 import io.grpc.MethodDescriptor
 import io.grpc.kotlin.AbstractCoroutineStub
-import konig.kontext.KONIG_KONTEXT_GRPC_HEADER_KEY
-import konig.kontext.KONIG_KONTEXT_GRPC_CONTEXT_KEY
 
 class KonigKontextClientInterceptor : ClientInterceptor {
     override fun <ReqT : Any?, RespT : Any?> interceptCall(

--- a/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextServer.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextServer.kt
@@ -1,10 +1,8 @@
-package org.konigsoftware.konig.kontext
+package org.konigsoftware.kontext
 
 import com.google.protobuf.Message
 import io.grpc.BindableService
 import io.grpc.ServerBuilder
-import konig.kontext.KONIG_KONTEXT_GRPC_CONTEXT_KEY
-import konig.kontext.KonigKontextServerInterceptor
 import kotlin.reflect.KClass
 
 interface KonigKontextServer<ContextType : Message> {

--- a/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextServerInterceptor.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextServerInterceptor.kt
@@ -1,10 +1,8 @@
-package konig.kontext
+package org.konigsoftware.kontext
 
 import com.google.protobuf.Message
-import io.grpc.BindableService
 import io.grpc.Context
 import io.grpc.Metadata
-import io.grpc.ServerBuilder
 import io.grpc.ServerCall
 import io.grpc.ServerCall.Listener
 import io.grpc.ServerCallHandler
@@ -13,7 +11,6 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.functions
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.safeCast
-import org.konigsoftware.konig.kontext.KonigKontextServer
 
 internal class KonigKontextServerInterceptor<ContextType : Message>(private val contextClass: KClass<ContextType>) :
     ServerInterceptor {

--- a/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextUtils.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontextUtils.kt
@@ -1,4 +1,4 @@
-package konig.kontext
+package org.konigsoftware.kontext
 
 import com.google.protobuf.Message
 import io.grpc.Context

--- a/lib/src/main/kotlin/org/konigsoftware/kontext/SharedKeys.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/SharedKeys.kt
@@ -1,10 +1,9 @@
-package konig.kontext
+package org.konigsoftware.kontext
 
 import com.google.protobuf.Message
 import io.grpc.Context
 import io.grpc.Metadata
 import io.grpc.Metadata.Key
-import kotlin.coroutines.CoroutineContext
 
 /**
  * gRPC header ([Metadata]) key whose value contains the binary version of the Konig Kontext

--- a/lib/src/main/kotlin/org/konigsoftware/kontext/WithKonigKontext.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/WithKonigKontext.kt
@@ -1,8 +1,6 @@
-package konig.kontext
+package org.konigsoftware.kontext
 
 import com.google.protobuf.Message
-import kotlin.coroutines.coroutineContext
-import kotlinx.coroutines.withContext
 import io.grpc.Context as GrpcContext
 
 suspend fun <T, ContextType : Message> withKonigKontext(


### PR DESCRIPTION
There were inconsistencies in the package names before, also moves some packages from `org.konigsoftware.konig.kontext` to `org.konigsoftware.kontext` which seems a bit cleaner