### PR TITLE
Integration tests + improved thread safety

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -35,8 +35,30 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("io.grpc:grpc-testing:1.58.0")
     testImplementation("io.grpc:grpc-examples:0.15.0")
+    testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
+    testImplementation("com.squareup.moshi:moshi-kotlin:1.14.0")
 }
 
 tasks.test {
     useJUnitPlatform()
+    filter {
+        includeTestsMatching("*Test")
+        this.isFailOnNoMatchingTests = true
+    }
+}
+
+tasks.register<Test>("integrationTest") {
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching("org.konigsoftware.kontext.*IT")
+        this.isFailOnNoMatchingTests = true
+    }
+}
+
+tasks.build {
+    tasks.getByName("integrationTest").enabled = false
+}
+
+tasks.check {
+    tasks.getByName("integrationTest").enabled = false
 }

--- a/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontext.kt
+++ b/lib/src/main/kotlin/org/konigsoftware/kontext/KonigKontext.kt
@@ -1,6 +1,8 @@
 package org.konigsoftware.kontext
 
 import io.grpc.Context
+import io.grpc.kotlin.GrpcContextElement
+import kotlinx.coroutines.withContext
 
 class KonigKontext<KontextValue> private constructor(
     internal val konigKontextKey: KonigKontextKey<KontextValue>,
@@ -23,13 +25,10 @@ class KonigKontext<KontextValue> private constructor(
 suspend fun <T, KontextValue> withKonigKontext(
     konigKontext: KonigKontext<KontextValue>,
     block: suspend () -> T
-): T {
-    val context =
+): T = withContext(
+    GrpcContextElement(
         Context.current().withValue(konigKontext.konigKontextKey.grpcContextKey, konigKontext.konigKontextValue)
-    val oldContext: Context = context.attach()
-    return try {
-        block()
-    } finally {
-        context.detach(oldContext)
-    }
+    )
+) {
+    block()
 }

--- a/lib/src/test/kotlin/org/konigsoftware/kontext/ExampleApiClient.kt
+++ b/lib/src/test/kotlin/org/konigsoftware/kontext/ExampleApiClient.kt
@@ -1,0 +1,68 @@
+package org.konigsoftware.kontext
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.IOException
+import java.util.logging.Logger
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
+internal class ExampleApiClient(private val baseUrl: String) {
+    private val httpClient = OkHttpClient.Builder().dispatcher(Dispatcher().let {
+        it.maxRequestsPerHost = 10
+        it
+    }).build()
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val logger = Logger.getLogger("org.konigsoftware.kontext.ExampleApiClient")
+
+    data class BalanceResponse(val balance: String)
+
+    suspend fun getBalance(userId: String, customerId: String): BalanceResponse? {
+        val request =
+            Request.Builder().url("$baseUrl/$userId/balance").get().addHeader("Customer-Id", customerId).build()
+
+        httpClient.newCall(request).executeSuspending().use {
+            val responseBody = it.body?.string() ?: ""
+
+            if (!it.isSuccessful) {
+                logger.severe("Call to $baseUrl/$userId/balance was unsuccessful. Error code: ${it.code}")
+                return null
+            }
+
+            return parseJson(moshi.adapter(BalanceResponse::class.java), responseBody)
+                ?: run {
+                    logger.severe("Unable to parse BalanceResponse from response body: $responseBody")
+                    null
+                }
+        }
+    }
+
+    private suspend fun Call.executeSuspending(): Response {
+        return suspendCoroutine { continuation ->
+            enqueue(object : Callback {
+                override fun onResponse(call: Call, response: Response) {
+                    continuation.resume(response)
+                }
+
+                override fun onFailure(call: Call, e: IOException) {
+                    continuation.resumeWithException(e)
+                }
+            })
+        }
+    }
+
+    private fun <T> parseJson(adapter: JsonAdapter<T>, json: String): T? = adapter.fromJson(json)
+
+    inline fun <reified T> T.toJson(): String {
+        val adapter = moshi.adapter(T::class.java)
+        return adapter.toJson(this)
+    }
+}

--- a/lib/src/test/kotlin/org/konigsoftware/kontext/KonigKontextImplementationIT.kt
+++ b/lib/src/test/kotlin/org/konigsoftware/kontext/KonigKontextImplementationIT.kt
@@ -1,0 +1,213 @@
+package org.konigsoftware.kontext
+
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.konigsoftware.kontext.ExampleApiClient.BalanceResponse
+
+internal class KonigKontextImplementationIT {
+    @Nested
+    inner class KotlinStackIT {
+        private val localKotlinApiClient = ExampleApiClient("http://localhost:8080")
+
+        @Test
+        fun `Given single user id and customer id, when calling example api GET balance on kotlin stack, then the correct balance is returned`() =
+            runBlocking {
+                val userId = "test_user_id_9876"
+                val customerId = "test_customer_id_1234"
+                val expectedBalance = "3301.42"
+
+                val balanceResponse = localKotlinApiClient.getBalance(userId, customerId)
+
+                assertNotNull(balanceResponse)
+                assertEquals(expectedBalance, balanceResponse.balance)
+            }
+
+        @Test
+        fun `Given two different user ids and customer id, when calling example api GET balance on kotlin stack at the same time, then the correct balances are returned`() =
+            runBlocking {
+                val userId1 = "test_user_id_9876"
+                val customerId1 = "test_customer_id_1234"
+                val expectedBalance1 = "3301.42"
+
+                val userId2 = "test_user_id_0000"
+                val customerId2 = "test_customer_id_0909"
+                val expectedBalance2 = "19.87"
+
+                lateinit var balanceResponse1: BalanceResponse
+                lateinit var balanceResponse2: BalanceResponse
+
+                val request1 = launch {
+                    balanceResponse1 = localKotlinApiClient.getBalance(userId1, customerId1) ?: fail("Request 1 failed")
+                }
+                val request2 = launch {
+                    balanceResponse2 = localKotlinApiClient.getBalance(userId2, customerId2) ?: fail("Request 2 failed")
+                }
+
+                request1.join()
+                request2.join()
+
+                assertNotNull(balanceResponse1)
+                assertEquals(expectedBalance1, balanceResponse1.balance)
+
+                assertNotNull(balanceResponse2)
+                assertEquals(expectedBalance2, balanceResponse2.balance)
+            }
+
+        @Test
+        fun `Given different user ids and customer ids, when calling example api GET balance on kotlin stack many times concurrently at the same time, then the correct balances are returned`() =
+            runBlocking {
+                val customerAndUserToExpectedBalance = linkedMapOf(
+                    ("test_customer_id_1234" to "test_user_id_9876") to "3301.42",
+                    ("test_customer_id_0909" to "test_user_id_0000") to "19.87",
+                    ("test_customer_id_9281" to "test_user_id_0091") to "8310.921",
+                    ("test_customer_id_9032" to "test_user_id_3802") to "889.223",
+                    ("test_customer_id_1123" to "test_user_id_8731") to "11.19",
+                    ("test_customer_id_8013" to "test_user_id_3385") to "71239.91",
+                    ("test_customer_id_1859" to "test_user_id_8358") to "89134.12",
+                    ("test_customer_id_8302" to "test_user_id_9090") to "83.1",
+                    ("test_customer_id_0909" to "test_user_id_0091") to "1.91",
+                    ("test_customer_id_1234" to "test_user_id_8921") to "8310.921",
+                )
+
+                val requestIndexToExpectedBalanceAndActualBalance = LinkedHashMap<Int, Pair<String, String>>(1000)
+                val requestJobs = mutableListOf<Job>()
+
+                for (i in 0..1000) {
+                    val randomBalanceRequest =
+                        customerAndUserToExpectedBalance.entries.toList()[Random.nextInt(
+                            customerAndUserToExpectedBalance.size
+                        )]
+                    val customerId = randomBalanceRequest.key.first
+                    val userId = randomBalanceRequest.key.second
+                    val expectedBalance = randomBalanceRequest.value
+
+                    val request = launch {
+                        val balanceResponse = localKotlinApiClient.getBalance(userId, customerId)
+
+                        assertNotNull(
+                            balanceResponse,
+                            "Getting balance for user: $userId and customer: $customerId failed"
+                        )
+
+                        println("GOT BALANCE FOR USER: $userId and customer: $customerId balance: ${balanceResponse.balance}")
+
+                        requestIndexToExpectedBalanceAndActualBalance[i] = expectedBalance to balanceResponse.balance
+                    }
+
+                    requestJobs.add(request)
+                }
+
+                requestJobs.joinAll()
+
+                requestIndexToExpectedBalanceAndActualBalance.values.forEach {
+                    assertEquals(it.first, it.second, "Expected balance: ${it.first} but got balance: ${it.second}")
+                }
+            }
+    }
+
+    @Nested
+    inner class JavaStackIT {
+        private val localJavaApiClient = ExampleApiClient("http://localhost:8081")
+
+        @Test
+        fun `Given single user id and customer id, when calling example api GET balance on java stack, then the correct balance is returned`() =
+            runBlocking {
+                val userId = "test_user_id_9876"
+                val customerId = "test_customer_id_1234"
+                val expectedBalance = "3301.42"
+
+                val balanceResponse = localJavaApiClient.getBalance(userId, customerId)
+
+                assertNotNull(balanceResponse)
+                assertEquals(expectedBalance, balanceResponse.balance)
+            }
+
+        @Test
+        fun `Given two different user ids and customer id, when calling example api GET balance on java stack at the same time, then the correct balances are returned`() =
+            runBlocking {
+                val userId1 = "test_user_id_9876"
+                val customerId1 = "test_customer_id_1234"
+                val expectedBalance1 = "3301.42"
+
+                val userId2 = "test_user_id_0000"
+                val customerId2 = "test_customer_id_0909"
+                val expectedBalance2 = "19.87"
+
+                lateinit var balanceResponse1: BalanceResponse
+                lateinit var balanceResponse2: BalanceResponse
+
+                val request1 = launch {
+                    balanceResponse1 = localJavaApiClient.getBalance(userId1, customerId1) ?: fail("Request 1 failed")
+                }
+                val request2 = launch {
+                    balanceResponse2 = localJavaApiClient.getBalance(userId2, customerId2) ?: fail("Request 2 failed")
+                }
+
+                request1.join()
+                request2.join()
+
+                assertNotNull(balanceResponse1)
+                assertEquals(expectedBalance1, balanceResponse1.balance)
+
+                assertNotNull(balanceResponse2)
+                assertEquals(expectedBalance2, balanceResponse2.balance)
+            }
+
+        @Test
+        fun `Given different user ids and customer ids, when calling example api GET balance on java stack many times concurrently at the same time, then the correct balances are returned`() =
+            runBlocking {
+                val customerAndUserToExpectedBalance = linkedMapOf(
+                    ("test_customer_id_1234" to "test_user_id_9876") to "3301.42",
+                    ("test_customer_id_0909" to "test_user_id_0000") to "19.87",
+                    ("test_customer_id_9281" to "test_user_id_0091") to "8310.921",
+                    ("test_customer_id_9032" to "test_user_id_3802") to "889.223",
+                    ("test_customer_id_1123" to "test_user_id_8731") to "11.19",
+                    ("test_customer_id_8013" to "test_user_id_3385") to "71239.91",
+                    ("test_customer_id_1859" to "test_user_id_8358") to "89134.12",
+                    ("test_customer_id_8302" to "test_user_id_9090") to "83.1",
+                    ("test_customer_id_0909" to "test_user_id_0091") to "1.91",
+                    ("test_customer_id_1234" to "test_user_id_8921") to "8310.921",
+                )
+
+                val requestIndexToExpectedBalanceAndActualBalance = LinkedHashMap<Int, Pair<String, String>>(1000)
+                val requestJobs = mutableListOf<Job>()
+
+                for (i in 0..1000) {
+                    val randomBalanceRequest =
+                        customerAndUserToExpectedBalance.entries.toList()[Random.nextInt(
+                            customerAndUserToExpectedBalance.size
+                        )]
+                    val customerId = randomBalanceRequest.key.first
+                    val userId = randomBalanceRequest.key.second
+                    val expectedBalance = randomBalanceRequest.value
+
+                    val request = launch {
+                        val balanceResponse = localJavaApiClient.getBalance(userId, customerId)
+
+                        assertNotNull(
+                            balanceResponse,
+                            "Getting balance for user: $userId and customer: $customerId failed"
+                        )
+
+                        requestIndexToExpectedBalanceAndActualBalance[i] = expectedBalance to balanceResponse.balance
+                    }
+
+                    requestJobs.add(request)
+                }
+
+                requestJobs.joinAll()
+
+                requestIndexToExpectedBalanceAndActualBalance.values.forEach {
+                    assertEquals(it.first, it.second, "Expected balance: ${it.first} but got balance: ${it.second}")
+                }
+            }
+    }
+}


### PR DESCRIPTION
Adds integration testing against example projects in both [kotlin](https://github.com/konigsoftware/konig-kontext-example-kotlin) and [java](https://github.com/konigsoftware/konig-kontext-example-java). Included is a test that attempts to send 1000 requests at the same time to the example backend (not all 1000 actually get sent at once due to the concurrency limitation on the OkHttpClient) in order to test the concurrency and thread safety of the package.

This test highlighted an issue with the old `withKonigKontext` function in the kotlin implementation. Since gRPC Context utilizes ThreadLocal, mutliple Kotlin coroutines can run on the same thread and potentially have access to the wrong gRPC Context. The [grpc-kotlin](https://github.com/grpc/grpc-kotlin) package ran into this issue as well, and implemented a custom CoroutineContext [element](https://github.com/grpc/grpc-kotlin/blob/master/stub/src/main/java/io/grpc/kotlin/GrpcContextElement.kt) specifically for ensuring that a given coroutine only can access its proper corresponding gRPC Context. I have utilized the same class to ensure that `withKonigKontext` is concurrency safe. Also, since grpc-kotlin has already solved this issue, any kotlin coroutine server implementations that register the `KonigKontextInterceptor` will also be concurrency safe. With these changes, all kotlin implementations should be concurrency safe.

All Java implementations were already concurrency safe since concurrent threads in Java are each their own thread and thus cannot have access to an incorrect gRPC Context.

Grpc-kotlin also has example projects inside the same repo as the library itself, so I'm going to use that as an example to try and see if I can get those projects moved into this repo. That way any breaking changes will require updating the examples and integration tests can be run on PRs